### PR TITLE
fix deadlock on dynamo read error for get tenant api in web hook code…

### DIFF
--- a/internal/pkg/app/handlers_v1.go
+++ b/internal/pkg/app/handlers_v1.go
@@ -365,6 +365,7 @@ func (a *APIManager) sendEventHandler(w http.ResponseWriter, r *http.Request) {
 			log.Ctx(ctx).Error().Str("op", "sendEventHandler").Str("error", err.Error()).Msg("error getting tenant config")
 			resp := ErrorResponse(convertToApiError(ctx, err))
 			resp.Respond(ctx, w, doYaml(r))
+			a.Unlock()
 			return
 		}
 		a.tenantCache.SetTenant(tenantConfig)


### PR DESCRIPTION
… (aka memory leak)