### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,20 @@ on:
       - MAINTAINERS.md
       - LICENSE
       - NOTICE
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents:      write
+  packages:      write
+
 jobs:
   ci:
-    uses: xmidt-org/.github/.github/workflows/go-ci.yml@go-ci-v1
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      sonarcloud-exclusions: '**/*_test.go,**/*testing.go,**/testing_mock.go,**/vendor/**,**/cmd/**,**/test/**,**/fx/**,**/dynamo/**,**/redis/**,**/http/**,**/sqs/**,**/kafka/**,**/s3/**'
-      lint-skip: true
-      style-skip: true
+      release-type:   library
+      yaml-lint-skip: false
     secrets: inherit

--- a/.github/workflows/dependabot-approver.yml
+++ b/.github/workflows/dependabot-approver.yml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
   pull_request_target
+
 permissions:
   pull-requests: write
-  contents: write
+  contents:      write
 
 jobs:
   package:

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'PROJ: xmidt-team'
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents:       read
+  issues:         write
+  pull-requests:  write
+
+jobs:
+  package:
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Updates ci.yml to use shared-go/.github/workflows/ci.yml with SHA pinning
- Adds required permissions blocks to all workflows  
- Creates auto-releaser.yml for automated patch releases
- Creates proj-xmidt-team.yml for project automation
- Adds proper SPDX headers to dependabot-approver.yml

## Changes

### ci.yml
- Changed from xmidt-org/.github/.github/workflows/go-ci.yml@go-ci-v1 to xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e (v4.9.41)
- Added top-level permissions block with pull-requests: read, contents: write, packages: write
- Replaced deprecated lint-skip/style-skip with yaml-lint-skip: false
- Added release-type: library parameter
- Added tags trigger for version tags
- Removed sonarcloud-exclusions (handled by shared workflow)

### dependabot-approver.yml
- Added SPDX copyright headers
- Formatted permissions block for consistency

### auto-releaser.yml (new)
- Creates automated daily patch releases
- Includes proper permissions block (contents: write)
- Uses SHA-pinned reference to shared-go/auto-releaser.yml@v4.9.41

### proj-xmidt-team.yml (new)
- Automates project board management for issues and PRs
- Includes required permissions (contents: read, issues: write, pull-requests: write)

Fixes #807